### PR TITLE
Bug fixing for end_month == 12

### DIFF
--- a/websvr/webserver.py
+++ b/websvr/webserver.py
@@ -187,7 +187,7 @@ def get_data():
     end_month = int(end.strftime("%m"))
     
     #Datetime iteration until endtime
-    while (counter_year < end_year or counter_month <= end_month):
+    while (counter_date <= end):
         month = str(counter_date.month)
         #Time to string conversions
         if counter_date.month < 10:


### PR DESCRIPTION
Fixed while condition that is used to concatenate required CSV files. Previous condition would always be true on end_month == 12 and the loop would keep going until year 10000, at which point the datetime function failed.